### PR TITLE
fix: ensure installation cards have equal height

### DIFF
--- a/src/app/ui/installation/_components/Card.tsx
+++ b/src/app/ui/installation/_components/Card.tsx
@@ -17,7 +17,7 @@ export function Card({ slug, icon, name, description }: CardProps) {
   return (
     <Link
       href={`/ui/installation/${slug}`}
-      className="group relative min-h-[300px] w-full max-w-[500px] rounded-xl border border-white/10 bg-neutral-950 px-7 pb-7 pt-10 duration-200 hover:bg-[#111111]"
+      className="group relative h-full min-h-[300px] w-full max-w-[500px] rounded-xl border border-white/10 bg-neutral-950 px-7 pb-7 pt-10 duration-200 hover:bg-[#111111]"
     >
       <GradientLine />
       <div


### PR DESCRIPTION
## Description
Fixed an issue where installation cards(Next.js & Vite) had inconsistent heights when descriptions varied in length, causing uneven layout in the grid.

## Changes Made
Added `h-full` class to the main card container in `src/app/ui/installation/_components/Card.tsx` to ensure all cards maintain equal height regardless of content length.

Before:
- Cards had varying heights based on description length
- This caused visual inconsistency in the grid layout

After:
- All cards now maintain equal height
- Grid layout appears more uniform and polished

## Files Changed
- src/app/ui/installation/_components/Card.tsx

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
Verified that cards maintain equal height with different description lengths in both desktop and mobile views.